### PR TITLE
redis-yet - upgrading vitest to 1.5.2

### DIFF
--- a/packages/cache-manager-redis-yet/package.json
+++ b/packages/cache-manager-redis-yet/package.json
@@ -49,7 +49,7 @@
     "@types/node": "20.12.7",
     "@typescript-eslint/eslint-plugin": "7.7.1",
     "@typescript-eslint/parser": "7.7.1",
-    "@vitest/coverage-v8": "1.4.0",
+    "@vitest/coverage-v8": "1.5.2",
     "dotenv-cli": "7.4.1",
     "eslint": "9.1.1",
     "eslint-config-prettier": "9.1.0",
@@ -58,7 +58,7 @@
     "prettier": "3.2.5",
     "rimraf": "^5.0.5",
     "typescript": "5.4.5",
-    "vitest": "1.4.0"
+    "vitest": "1.5.2"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/node-cache-manager/cache-manager/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
redis-yet - upgrading vitest to 1.5.2