### PR TITLE
feat: add details to error event 

### DIFF
--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -170,10 +170,11 @@ See unit tests in [`test/multi-caching.test.ts`](./test/multi-caching.test.ts) f
 
 ### Cache Manager Options
 
-The `caching` and `multiCaching` functions accept an options object as the second parameter. The following options are available:
-* max: The maximum number of items that can be stored in the cache. If the cache is full, the least recently used item is removed.
+The `caching` function accepts an options object as the second parameter. The following options are available:
 * ttl: The time to live in milliseconds. This is the maximum amount of time that an item can be in the cache before it is removed.
-* shouldCloneBeforeSet: If true, the value will be cloned before being set in the cache. This is set to `true` by default.
+* refreshThreshold: discussed in details below.
+* isCacheable: a function to determine whether the value is cacheable or not.
+* onBackgroundRefreshError: a function to handle errors that occur during background refresh.
 
 ```typescript
 import { caching } from 'cache-manager';
@@ -184,6 +185,10 @@ const memoryCache = await caching('memory', {
   shouldCloneBeforeSet: false, // this is set true by default (optional)
 });
 ```
+
+When creating a memory store, you also get these addition options:
+* max: The maximum number of items that can be stored in the cache. If the cache is full, the least recently used item is removed.
+* shouldCloneBeforeSet: If true, the value will be cloned before being set in the cache. This is set to `true` by default.
 
 ### Refresh cache keys in background
 
@@ -219,14 +224,11 @@ When a value will be retrieved from Redis with a TTL minor than 3sec, the value 
 
 ## Error Handling
 
-Cache Manager now does not throw errors by default. Instead, all errors are evented through the `error` event. Here is an example on how to use it:
+`multiCaching` now does not throw errors by default. Instead, all errors are evented through the `error` event. Here is an example on how to use it:
 
 ```javascript
-const memoryCache = await caching('memory', {
-  max: 100,
-  ttl: 10 * 1000 /*milliseconds*/,
-});
-memoryCache.on('error', (error) => {
+const multicache = await multiCaching([memoryCache, someOtherCache]);
+multicache.on('error', (error) => {
   console.error('Cache error:', error);
 });
 ```

--- a/packages/cache-manager/test/caching.test.ts
+++ b/packages/cache-manager/test/caching.test.ts
@@ -327,14 +327,17 @@ describe('caching', () => {
 				const cache = await caching('memory');
 				cache.store.get = vi.fn().mockRejectedValue(error);
 
-				let errorMessage;
+				let errorEvent;
 				cache.on('error', error => {
-					errorMessage = error;
+					errorEvent = error;
 				});
 
 				await cache.wrap(key, function_);
 
-				expect(errorMessage).not.toBeUndefined();
+				expect(errorEvent!.error).not.toBeUndefined();
+				expect(errorEvent!.key).toBe(key);
+				expect(errorEvent!.operation).toBe('wrap');
+				expect(errorEvent!.data).toBeUndefined();
 				expect(function_).toHaveBeenCalled();
 			});
 
@@ -344,14 +347,17 @@ describe('caching', () => {
 				const cache = await caching('memory');
 				cache.store.set = vi.fn().mockRejectedValue(error);
 
-				let errorMessage;
+				let errorEvent;
 				cache.on('error', error => {
-					errorMessage = error;
+					errorEvent = error;
 				});
 
 				await cache.wrap(key, function_);
 
-				expect(errorMessage).not.toBeUndefined();
+				expect(errorEvent!.error).not.toBeUndefined();
+				expect(errorEvent!.key).toBe(key);
+				expect(errorEvent!.operation).toBe('wrap');
+				expect(errorEvent!.data).toBe(value);
 			});
 		});
 	});

--- a/packages/cache-manager/test/multi-caching.test.ts
+++ b/packages/cache-manager/test/multi-caching.test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable max-nested-callbacks */
-import {beforeEach, describe, expect, it, vi,} from 'vitest';
+import {
+	beforeEach, describe, expect, it, vi,
+} from 'vitest';
 import {faker} from '@faker-js/faker';
-import {type Cache, caching, type MemoryCache, type MultiCache, multiCaching, type Store,} from '../src/index.js';
+import {
+	type Cache, caching, type MemoryCache, type MultiCache, multiCaching, type Store,
+} from '../src/index.js';
 import {sleep} from './utils.js';
 
 describe('multiCaching', () => {

--- a/packages/cache-manager/test/multi-caching.test.ts
+++ b/packages/cache-manager/test/multi-caching.test.ts
@@ -1,16 +1,7 @@
 /* eslint-disable max-nested-callbacks */
-import {
-	describe, expect, it, beforeEach, vi,
-} from 'vitest';
+import {beforeEach, describe, expect, it, vi,} from 'vitest';
 import {faker} from '@faker-js/faker';
-import {
-	type Cache,
-	caching,
-	type MemoryCache,
-	type MultiCache,
-	multiCaching,
-	type Store,
-} from '../src/index.js';
+import {type Cache, caching, type MemoryCache, type MultiCache, multiCaching, type Store,} from '../src/index.js';
 import {sleep} from './utils.js';
 
 describe('multiCaching', () => {
@@ -199,6 +190,7 @@ describe('multiCaching', () => {
 				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 				store: {} as Store,
 				on: empty,
+				removeListener: empty,
 			};
 
 			const setErrorCache: Cache = {
@@ -212,6 +204,7 @@ describe('multiCaching', () => {
 				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 				store: {} as Store,
 				on: empty,
+				removeListener: empty,
 			};
 
 			const cacheEmpty: Cache = {
@@ -223,6 +216,7 @@ describe('multiCaching', () => {
 				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 				store: {} as Store,
 				on: empty,
+				removeListener: empty,
 			};
 
 			it('should get error', async () => {
@@ -251,38 +245,45 @@ describe('multiCaching', () => {
 
 			it('emits an error event when store.get() fails', async () => {
 				multiCache = multiCaching([getErrorCache, memoryCache]);
-				let errorMessage;
+				let errorEvent;
 				multiCache.on('error', error => {
-					errorMessage = error;
+					errorEvent = error;
 				});
 
 				await multiCache.get(key);
 
-				expect(errorMessage).not.toBeUndefined();
+				expect(errorEvent!.error).not.toBeUndefined();
+				expect(errorEvent!.operation).toBe('get');
+				expect(errorEvent!.key).toBe(key);
 			});
 
 			it('should receive error event on set failure', async () => {
 				multiCache = multiCaching([setErrorCache, memoryCache]);
-				let errorMessage;
+				let errorEvent;
 				multiCache.on('error', error => {
-					errorMessage = error;
+					errorEvent = error;
 				});
 
 				await multiCache.set(key, value);
 
-				expect(errorMessage).not.toBeUndefined();
+				expect(errorEvent!.error).not.toBeUndefined();
+				expect(errorEvent!.key).toBe(key);
+				expect(errorEvent!.data).toBe(value);
+				expect(errorEvent!.operation).toBe('set');
 			});
 
 			it('should receive error event on mget failure', async () => {
 				multiCache = multiCaching([setErrorCache, memoryCache]);
-				let errorMessage;
+				let errorEvent;
 				multiCache.on('error', error => {
-					errorMessage = error;
+					errorEvent = error;
 				});
+				const key2 = value;
+				await multiCache.mget(key, key2);
 
-				await multiCache.mget(key, value);
-
-				expect(errorMessage).not.toBeUndefined();
+				expect(errorEvent!.error).not.toBeUndefined();
+				expect(errorEvent!.keys).toStrictEqual([key, key2]);
+				expect(errorEvent!.operation).toBe('mget');
 			});
 
 			it('should receive error event on get failure during wrap', async () => {
@@ -290,14 +291,17 @@ describe('multiCaching', () => {
 				const error = new Error('store.get() failed');
 				const function_ = vi.fn().mockResolvedValue(value);
 
-				let errorMessage;
+				let errorEvent;
 				multiCache.on('error', error => {
-					errorMessage = error;
+					errorEvent = error;
 				});
 
 				await multiCache.wrap(key, function_);
 
-				expect(errorMessage).not.toBeUndefined();
+				expect(errorEvent!.error).not.toBeUndefined();
+				expect(errorEvent!.operation).toBe('wrap');
+				expect(errorEvent!.key).toBe(key);
+				expect(errorEvent!.data).toBeUndefined();
 			});
 		});
 	});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/node-cache-manager/cache-manager/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
When using `caching.on` and `multicaching.on`, there's no way to:
* Know the circumstances that caused the error (key, data, operation, etc...)
* Unsubscribe from the emitter

Introducing this changes, consumers can better monitor and classify errors. 