### PR TITLE
Fix express example having a 10ms instead of 10 second cache ttl

### DIFF
--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -244,7 +244,7 @@ import express from 'express';
 // The memory cache is initialized using cache-manager with a maximum of 100 items and a TTL (time-to-live) of 10 seconds:
 const memoryCache = await caching('memory', {
   max: 100,
-  ttl: 10 /* seconds */
+  ttl: 10 * 1000 /*milliseconds*/
 });
 
 const app = express();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cache-manager/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** Docs update

Im new to this library and was scratching my head for a good hour as to why the middleware example wasnt working, then i discovered the TTL was incorrectly configured, this PR makes a minor adjustment to fix that.