### PR TITLE
non-blocking set for wrap function

### DIFF
--- a/packages/cache-manager/README.md
+++ b/packages/cache-manager/README.md
@@ -232,6 +232,17 @@ multicache.on('error', (error) => {
 });
 ```
 
+## Using non-blocking set with wrap
+By default, when using `wrap` the value is set in the cache before the function returns. 
+While this behaviour can prevent additional calls to downstream resources, it can also slow down the response time.
+This can be changed by setting the `nonBlockingSet` option to `true`. 
+Doing will make the function return before the value is set in the cache.
+The setting applies to both single and multi caches. 
+
+```typescript
+cache.wrap('key', () => fetchValue(), 1000, 500, {nonBlockingSet: true});
+```
+
 ## Express Middleware
 
 This example sets up an Express application with a caching mechanism using cache-manager. The cacheMiddleware checks if the response for a request is already cached and returns it if available. If not, it proceeds to the route handler, caches the response, and then returns it. This helps to reduce the load on the server by avoiding repeated processing of the same requests.

--- a/packages/cache-manager/src/multi-caching.ts
+++ b/packages/cache-manager/src/multi-caching.ts
@@ -91,7 +91,6 @@ export function multiCaching<Caches extends Cache[]>(
 
 			const cacheTtl = typeof ttl === 'function' ? ttl(value) : ttl;
 			await conditionalAwait(async () => set(key, value, cacheTtl, i).then(async () => caches[i].wrap(key, function_, ttl, refreshThreshold)), !options_.nonBlockingSet);
-			
 			return value;
 		},
 		async reset() {

--- a/packages/cache-manager/src/multi-caching.ts
+++ b/packages/cache-manager/src/multi-caching.ts
@@ -1,7 +1,8 @@
 import EventEmitter from 'eventemitter3';
 import {
-	type Cache, type Milliseconds, type WrapTTL, type ErrorEvent,
+	type Cache, type Milliseconds, type WrapTTL, type ErrorEvent, type WrapOptions, defaultWrapOptions,
 } from './caching.js';
+import {conditionalAwait} from './utils.js';
 
 export type MultiCache = Omit<Cache, 'store'> &
 Pick<Cache['store'], 'mset' | 'mget' | 'mdel'>;
@@ -36,8 +37,9 @@ export function multiCaching<Caches extends Cache[]>(
 		key: string,
 		data: T,
 		ttl?: Milliseconds | undefined,
+		slice: number = caches.length,
 	) => {
-		await Promise.all(caches.map(async cache => cache.set(key, data, ttl))).catch(error => {
+		await Promise.all(caches.slice(0, slice).map(async cache => cache.set(key, data, ttl))).catch(error => {
 			const errorEvent: ErrorEvent<T> = {
 				error, key, operation: 'set', data,
 			};
@@ -47,7 +49,9 @@ export function multiCaching<Caches extends Cache[]>(
 
 	return {
 		get,
-		set,
+		async set(key, value, ttl) {
+			await set(key, value, ttl);
+		},
 		async del(key) {
 			await Promise.all(caches.map(async cache => cache.del(key))).catch(error => {
 				const errorEvent: ErrorEvent = {error, key, operation: 'del'};
@@ -59,7 +63,9 @@ export function multiCaching<Caches extends Cache[]>(
 			function_: () => Promise<T>,
 			ttl?: WrapTTL<T>,
 			refreshThreshold?: Milliseconds,
+			options: WrapOptions = {},
 		): Promise<T> {
+			const options_ = {...defaultWrapOptions, ...options};
 			let value: T | undefined;
 			let i = 0;
 			for (; i < caches.length; i++) {
@@ -70,7 +76,7 @@ export function multiCaching<Caches extends Cache[]>(
 						break;
 					}
 				} catch (error) {
-					const errorEvent: ErrorEvent<T> = {error, key, operation: 'wrap'};
+					const errorEvent: ErrorEvent<T> = {error, key, operation: 'get'};
 					eventEmitter.emit('error', errorEvent);
 				}
 			}
@@ -78,22 +84,14 @@ export function multiCaching<Caches extends Cache[]>(
 			if (value === undefined) {
 				const result = await function_();
 				const cacheTtl = typeof ttl === 'function' ? ttl(result) : ttl;
-				await set<T>(key, result, cacheTtl);
+				await conditionalAwait(async () => set(key, result, cacheTtl), !options_.nonBlockingSet);
+
 				return result;
 			}
 
 			const cacheTtl = typeof ttl === 'function' ? ttl(value) : ttl;
-			await Promise.all(
-				caches.slice(0, i).map(async cache => cache.set(key, value, cacheTtl)),
-			).then().catch(error => {
-				const errorEvent: ErrorEvent<T> = {
-					error, key, operation: 'wrap', data: value,
-				};
-				eventEmitter.emit('error', errorEvent);
-			});
-
-			await caches[i].wrap(key, function_, ttl, refreshThreshold).then(); // Call wrap for store for internal refreshThreshold logic, see: src/caching.ts caching.wrap
-
+			await conditionalAwait(async () => set(key, value, cacheTtl, i).then(async () => caches[i].wrap(key, function_, ttl, refreshThreshold)), !options_.nonBlockingSet);
+			
 			return value;
 		},
 		async reset() {

--- a/packages/cache-manager/src/utils.ts
+++ b/packages/cache-manager/src/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * If blocking is true, it will await the function before returning.
+ * Otherwise, it will fire the execution and return before it ends.
+ * Consumer of this function should await the returned promise.
+ * @param function_
+ * @param blocking
+ */
+export const conditionalAwait = async (function_: () => Promise<unknown>, blocking: boolean): Promise<void> => {
+	if (blocking) {
+		await function_();
+	} else {
+		void function_().then();
+	}
+};

--- a/packages/cache-manager/test/utils.test.ts
+++ b/packages/cache-manager/test/utils.test.ts
@@ -1,0 +1,32 @@
+import {
+	describe, vi, it, expect,
+} from 'vitest';
+import {conditionalAwait} from '../src/utils.js';
+
+describe('utils', () => {
+	describe('conditionalAwait', () => {
+		const longTask = vi.fn(async () => new Promise<void>(resolve => {
+			setTimeout(() => {
+				resolve(undefined);
+			}, 1000);
+		}));
+
+		it('should await function when blocking is true', async () => {
+			const start = Date.now();
+			await conditionalAwait(longTask, true);
+			const duration = Date.now() - start;
+
+			expect(longTask).toHaveBeenCalled();
+			expect(duration).toBeGreaterThanOrEqual(1000);
+		});
+
+		it('should not await function when blocking is false', async () => {
+			const start = Date.now();
+			await conditionalAwait(longTask, false);
+			const duration = Date.now() - start;
+
+			expect(longTask).toHaveBeenCalled();
+			expect(duration).toBeLessThan(100); // Should proceed almost immediately
+		});
+	});
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cache-manager/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Introducing non-blocking set for wrap operations. 
In V4 when the wrap operation was called, results were returned before backfilling the cache(s).
This changed in V5 and cache(s) are backfilled before returning results, leading to slower throughput. 

This PR adds the option to restore the behaviour of V4. 