### PR TITLE
cache-manager - fix moving back to lru-cache version ^10.2.2

### DIFF
--- a/packages/cache-manager/package.json
+++ b/packages/cache-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-manager",
-  "version": "5.7.2",
+  "version": "5.7.3",
   "description": "Cache module for Node.js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -47,7 +47,7 @@
   "dependencies": {
     "eventemitter3": "^5.0.1",
     "lodash.clonedeep": "^4.5.0",
-    "lru-cache": "^11.0.0",
+    "lru-cache": "^10.2.2",
     "promise-coalesce": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] Followed the [Contributing](https://github.com/jaredwray/cache-manager/blob/main/CONTRIBUTING.md) guidelines.
- [x] Tests for the changes have been added (for bug fixes/features) with 100% code coverage.
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
cache-manager - fix moving back to lru-cache version ^10.2.2